### PR TITLE
Revert "$_POST['passwrd2'] is no longer relevant when reloading user …

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3012,9 +3012,15 @@ function profileReloadUser()
 {
 	global $sourcedir, $modSettings, $context, $cur_profile, $smcFunc, $profile_vars;
 
-	// Log them back in
-	require_once($sourcedir . '/Subs-Auth.php');
-	setLoginCookie(60 * $modSettings['cookieTime'], $context['id_member'], sha1($cur_profile['passwrd1'] . $cur_profile['password_salt']));
+	// Log them back in - check that the verify password is set as this
+	// one doesn't get changed, so it's a reliable indicator that the
+	// password is being updated.
+	if (isset($_POST['passwrd2']) && $_POST['passwrd2'] != '')
+	{
+		require_once($sourcedir . '/Subs-Auth.php');
+		setLoginCookie(60 * $modSettings['cookieTime'], $context['id_member'], sha1($cur_profile['passwrd1'] . $cur_profile['password_salt']));
+	}
+
 	loadUserSettings();
 	writeLog();
 }


### PR DESCRIPTION
…settings"

This reverts commit d0bda62265b1f9bc5be9bc88f664d01876be267a.

Also, clarify this comment to avoid future misunderstandings like the one that caused us to remove this check in the first place.