### PR TITLE
Set $utf8 to true

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -164,8 +164,8 @@ function reloadSettings()
 			cache_put_data('modSettings', $modSettings, 90);
 	}
 
-	// UTF-8 in regular expressions is unsupported on PHP(win) versions < 4.2.3.
-	$utf8 = (empty($modSettings['global_character_set']) ? $txt['lang_character_set'] : $modSettings['global_character_set']) === 'UTF-8' && (strpos(strtolower(PHP_OS), 'win') === false || @version_compare(PHP_VERSION, '4.2.3') != -1);
+	// A legacy check for UTF-8 support used to live here, but it seems to produce false negatives. In the long term, it would be preferable to simply remove all checks for $utf8 from the application
+	$utf8 = true;
 
 	// Set a list of common functions.
 	$ent_list = empty($modSettings['disableEntityCheck']) ? '&(#\d{1,7}|quot|amp|lt|gt|nbsp);' : '&(#021|quot|amp|lt|gt|nbsp);';


### PR DESCRIPTION
It appears that this variable's only purpose is to ensure that we are not running PHP < 4.2.3 on Windows. This is an extremely unlikely scenario these days, and other parts of this check appear to be broken (namely, we're checking the contents of $txt and $modSettings before they're even set).

$utf8 is checked in a fair amount of places and guides many of the application's assumptions - the issue was originally found while investigating edge cases in $smcFunc['substr']

It is still a good idea to investigate this further - clearly someone assumed that these variables would have been set by this point, and the fact that they aren't could be a symptom of a larger issue

It is also worth considering a broader refactoring of the application and simply removing this variable from the bigger picture. Nonetheless, this should be a step in the right direction