### PR TITLE
Imagemagick resizing

### DIFF
--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -310,39 +310,13 @@ function checkImagick()
 function resizeImageFile($source, $destination, $max_width, $max_height, $preferred_format = 0)
 {
 	global $sourcedir;
-	require_once($sourcedir . '/Subs-Package.php');
 	@ini_set('memory_limit', '90M');
 	
 	//Can we do this with ImageMagick?
 	if(checkImagick())
 	{
 		// Get the image file, we have to work with something after all
-		$fp_destination = fopen($destination, 'wb');
-		if ($fp_destination && (substr($source, 0, 7) == 'http://' || substr($source, 0, 8) == 'https://'))
-		{
-			$fileContents = fetch_web_data($source);
-
-			fwrite($fp_destination, $fileContents);
-			fclose($fp_destination);
-		}
-		elseif ($fp_destination)
-		{
-			$fp_source = fopen($source, 'rb');
-			if ($fp_source !== false)
-			{
-				while (!feof($fp_source))
-					fwrite($fp_destination, fread($fp_source, 8192));
-				fclose($fp_source);
-			}
-			else
-			{
-				fclose($fp_destination);
-				return false; //Can't open source file
-			}
-			
-		}
-		// We can't write to the destination file.
-		else
+		if(!copy($source, $destination))
 			return false;
 
 		$imagick = new Imagick();

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -234,10 +234,6 @@ function createThumbnail($source, $max_width, $max_height)
 
 function reencodeImage($fileName, $preferred_format = 0)
 {
-	// There is nothing we can do without GD, sorry!
-	if (!checkGD())
-		return false;
-
 	if (!resizeImageFile($fileName, $fileName . '.tmp', null, null, $preferred_format))
 	{
 		if (file_exists($fileName . '.tmp'))

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -318,38 +318,45 @@ function resizeImageFile($source, $destination, $max_width, $max_height, $prefer
 		// Get the image file, we have to work with something after all
 		if(!copy($source, $destination))
 			return false;
-
-		$imagick = new Imagick();
-		$imagick->readImage($destination);
-		$imageformat = $imagick->getImageFormat();
-		$gif = ($imageformat === 'GIF');
-		if ($gif) // If this is a GIF, we need to coalesce all frames to ensure they're all of the same size
-			$imagick = $imagick->coalesceImages();
-		do
+		try
 		{
-			$imagick->gammaImage(0.45454545); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
+			$imagick = new Imagick();
+			$imagick->readImage($destination);
+			$imageformat = $imagick->getImageFormat();
+			$gif = ($imageformat === 'GIF');
+			if ($gif) // If this is a GIF, we need to coalesce all frames to ensure they're all of the same size
+				$imagick = $imagick->coalesceImages();
+			do
+			{
+				$imagick->gammaImage(0.45454545); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
 
-			// if either the width or height are null, set the current dimension to be the maximum
-			if($max_width === null)
-				$max_width = $imagick->getImageWidth();
-			if($max_height === null)
-				$max_height = $imagick->getImageHeight();
+				// if either the width or height are null, set the current dimension to be the maximum
+				if($max_width === null)
+					$max_width = $imagick->getImageWidth();
+				if($max_height === null)
+					$max_height = $imagick->getImageHeight();
+				
+				// FILTER_CATROM has been chosen as a middle ground between performance and quality. Could be changed to FILTER_BOX if performance is struggling
+				$imagick->resizeImage($max_width, $max_height, Imagick::FILTER_CATROM, 1, true, false);
+				$imagick->gammaImage(2.2); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
+			} while ($imagick->nextImage());
+
+			if ($gif) // Now that all frames have been resized, we can deconstruct it back to a progressive GIF
+				$imagick = $imagick->deconstructImages();
+
+			//If the preferred format is set to 3 (PNG), respect it for things that aren't gifs
+			if(!$gif && $preferred_format == 3)
+				$imagick->setImageFormat('PNG');
+			$imagick->writeImages($destination, true);
+			$imagick->clear();
 			
-			// FILTER_CATROM has been chosen as a middle ground between performance and quality. Could be changed to FILTER_BOX if performance is struggling
-			$imagick->resizeImage($max_width, $max_height, Imagick::FILTER_CATROM, 1, true, false);
-			$imagick->gammaImage(2.2); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
-		} while ($imagick->nextImage());
-
-		if ($gif) // Now that all frames have been resized, we can deconstruct it back to a progressive GIF
-			$imagick = $imagick->deconstructImages();
-
-		//If the preferred format is set to 3 (PNG), respect it for things that aren't gifs
-		if(!$gif && $preferred_format == 3)
-			$imagick->setImageFormat('PNG');
-		$imagick->writeImages($destination, true);
-		$imagick->clear();
-		
-		return true;
+			return true;
+		}
+		catch (Exception $imagick_exception)
+		{
+			log_error($imagick_exception->getMessage(), 'general', $imagick_exception->getFile(), $imagick_exception->getLine());
+			return false;
+		}
 	}
 	else //Default to SMF default function
 		return legacyResizeImageFile($source, $destination, $max_width, $max_height, $preferred_format);

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -312,54 +312,51 @@ function resizeImageFile($source, $destination, $max_width, $max_height, $prefer
 	global $sourcedir;
 	@ini_set('memory_limit', '90M');
 	
-	//Can we do this with ImageMagick?
-	if(checkImagick())
-	{
-		// Get the image file, we have to work with something after all
-		if(!copy($source, $destination))
-			return false;
-		try
-		{
-			$imagick = new Imagick();
-			$imagick->readImage($destination);
-			$imageformat = $imagick->getImageFormat();
-			$gif = ($imageformat === 'GIF');
-			if ($gif) // If this is a GIF, we need to coalesce all frames to ensure they're all of the same size
-				$imagick = $imagick->coalesceImages();
-			do
-			{
-				$imagick->gammaImage(0.45454545); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
-
-				// if either the width or height are null, set the current dimension to be the maximum
-				if($max_width === null)
-					$max_width = $imagick->getImageWidth();
-				if($max_height === null)
-					$max_height = $imagick->getImageHeight();
-				
-				// FILTER_CATROM has been chosen as a middle ground between performance and quality. Could be changed to FILTER_BOX if performance is struggling
-				$imagick->resizeImage($max_width, $max_height, Imagick::FILTER_CATROM, 1, true, false);
-				$imagick->gammaImage(2.2); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
-			} while ($imagick->nextImage());
-
-			if ($gif) // Now that all frames have been resized, we can deconstruct it back to a progressive GIF
-				$imagick = $imagick->deconstructImages();
-
-			//If the preferred format is set to 3 (PNG), respect it for things that aren't gifs
-			if(!$gif && $preferred_format == 3)
-				$imagick->setImageFormat('PNG');
-			$imagick->writeImages($destination, true);
-			$imagick->clear();
-			
-			return true;
-		}
-		catch (Exception $imagick_exception)
-		{
-			log_error($imagick_exception->getMessage(), 'general', $imagick_exception->getFile(), $imagick_exception->getLine());
-			return false;
-		}
-	}
-	else //Default to SMF default function
+	//Can we do this with ImageMagick? If not, default to legacy functions.
+	if(!checkImagick())
 		return legacyResizeImageFile($source, $destination, $max_width, $max_height, $preferred_format);
+	// Get the image file, we have to work with something after all
+	if(!copy($source, $destination))
+		return false;
+	try
+	{
+		$imagick = new Imagick();
+		$imagick->readImage($destination);
+		$imageformat = $imagick->getImageFormat();
+		$gif = ($imageformat === 'GIF');
+		if ($gif) // If this is a GIF, we need to coalesce all frames to ensure they're all of the same size
+			$imagick = $imagick->coalesceImages();
+		do
+		{
+			$imagick->gammaImage(0.45454545); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
+
+			// if either the width or height are null, set the current dimension to be the maximum
+			if($max_width === null)
+				$max_width = $imagick->getImageWidth();
+			if($max_height === null)
+				$max_height = $imagick->getImageHeight();
+			
+			// FILTER_CATROM has been chosen as a middle ground between performance and quality. Could be changed to FILTER_BOX if performance is struggling
+			$imagick->resizeImage($max_width, $max_height, Imagick::FILTER_CATROM, 1, true, false);
+			$imagick->gammaImage(2.2); // Work around gamma error, see http://www.ericbrasseur.org/gamma.html
+		} while ($imagick->nextImage());
+
+		if ($gif) // Now that all frames have been resized, we can deconstruct it back to a progressive GIF
+			$imagick = $imagick->deconstructImages();
+
+		//If the preferred format is set to 3 (PNG), respect it for things that aren't gifs
+		if(!$gif && $preferred_format == 3)
+			$imagick->setImageFormat('PNG');
+		$imagick->writeImages($destination, true);
+		$imagick->clear();
+		
+		return true;
+	}
+	catch (Exception $imagick_exception)
+	{
+		log_error($imagick_exception->getMessage(), 'general', $imagick_exception->getFile(), $imagick_exception->getLine());
+		return false;
+	}
 }
 
 function legacyResizeImageFile($source, $destination, $max_width, $max_height, $preferred_format = 0)


### PR DESCRIPTION
Use Imagemagick for resizing image files. This allows for a faster and more efficient way of resizing avatars and attachments.

It is worth noting that several security concerns were raised while writing this change, and that image upload validation will need to be implemented in the future. However, this is not strictly connected to how images are resized, and indeed using imagemagick likely increases security in most use cases.