### PR TITLE
Use sans-serif as a fallback font in body

### DIFF
--- a/Themes/blanko_fes/css/index.css
+++ b/Themes/blanko_fes/css/index.css
@@ -38,7 +38,7 @@ body
     margin: 0 auto;
     padding: 0;
     background-color: #ebebeb;
-	font-family: 'Open Sans', sans-serif;
+    font-family: 'Open Sans', sans-serif;
 }
 
 /* Help popups require a different styling of the body element. */

--- a/Themes/blanko_fes/css/index.css
+++ b/Themes/blanko_fes/css/index.css
@@ -30,12 +30,15 @@ table
     empty-cells: show;
 }
 
-/* Set a fontsize that will look the same in all browsers. */
+/* Set a fontsize that will look the same in all browsers.
+   Override Bootstrap's default font to fall back to sans-serif.
+*/
 body
 {
     margin: 0 auto;
     padding: 0;
     background-color: #ebebeb;
+	font-family: 'Open Sans', sans-serif;
 }
 
 /* Help popups require a different styling of the body element. */


### PR DESCRIPTION
The default specified in bootstrap.css is 'Open Sans' with no fallbacks provided. On Windows, this means that any missing glyphs will be rendered in Times New Roman. The system's default sans-serif font should be preferred to blend in more easily.