### PR TITLE
Disable WIRELESS mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -146,7 +146,7 @@ elseif (!isset($_SESSION['nowap']))
 }
 
 if (!defined('WIRELESS'))
-	define('WIRELESS', isset($_REQUEST['wap']) || isset($_REQUEST['wap2']) || isset($_REQUEST['imode']));
+	define('WIRELESS', false);
 
 // Some settings and headers are different for wireless protocols.
 if (WIRELESS)


### PR DESCRIPTION
SMF provides additonal views for ancient mobile phone users. These are not actually used, and we stopped linking to them years ago. This commit ensures that any references to these modes will be ignored.