### PR TITLE
Remove redundant user-agent check

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -713,9 +713,6 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 		$log_error = true;
 	}
 
-	if (strtolower($_SERVER['HTTP_USER_AGENT']) == 'hacker')
-		fatal_error('Sound the alarm!  It\'s a hacker!  Close the castle gates!!', false);
-
 	// Everything is ok, return an empty string.
 	if (!isset($error))
 		return '';


### PR DESCRIPTION
An arbitrary user-agent check has been removed - nobody gives a shit if your UA spells out the word "hacker".