### PR TITLE
Assign all variables while processing YouTube start timestamps

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1927,6 +1927,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 								$startpattern = '~[?&;](?:star)?t=(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s?)?~';
 								preg_match ($startpattern, $matches[0], $startmatches);
 								// Translate from a hours/minutes/seconds format to seconds only
+								// Apparently allowing these values to be empty makes PHP grumpy, so let's explicitly set them to 0 as needed
+								$startmatches[1] = empty($startmatches[1]) ? 0 : $startmatches[1];
+								$startmatches[2] = empty($startmatches[2]) ? 0 : $startmatches[2];
+								$startmatches[3] = empty($startmatches[3]) ? 0 : $startmatches[3];
 								$startval = $startmatches[1]*3600 + $startmatches[2]*60 + $startmatches[3];
 								// Do we have a meaningful start timestamp? Assume that start
 								// times greater than 1 week are bogus input.


### PR DESCRIPTION
In order to support old-style YouTube links, the old timestamp format of ?t=1h1m1s needs to be converted to seconds-only (?t=3661). Our old code solved this by splitting the timestamp string into an array of variables and multiplying/adding the values appropriately. Any unused variables would be left null, which in turn would generate up to 3 errors in SMF's error log per [youtube] tag view.

This commit ensures that these variables are set to 0 if empty, hopefully preventing meaningless error log spam.