### PR TITLE
Avoid uninitialised variable errors

### DIFF
--- a/Sources/Unsubscribe.php
+++ b/Sources/Unsubscribe.php
@@ -50,7 +50,7 @@ function Unsubscribe() {
 function CheckUnsubscribe() {
 	global $context, $smcFunc, $user_info;
 
-	if ($context['is_subscribed'] or $context['is_unsubscribed'])
+	if (!empty($context['is_subscribed']) or !empty($context['is_unsubscribed']))
 		return;
 
 	$topic = $context['current_topic'];


### PR DESCRIPTION
The whole point of this check is to find out if one of these is already set, so we don't need to be informed when they aren't.