### PR TITLE
Stop mangling UTF-8 when quick-editing posts

### DIFF
--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -310,8 +310,8 @@ QuickModify.prototype.modifySave = function (sSessionId, sSessionVar)
 		sSessionVar = 'sesc';
 
 	var i, x = new Array();
-	x[x.length] = 'subject=' + document.forms.quickModForm['subject'].value.replace(/&#/g, "&#38;#").php_to8bit().replace(/\+/g, "%2B");
-	x[x.length] = 'message=' + document.forms.quickModForm['message'].value.replace(/&#/g, "&#38;#").php_to8bit().replace(/\+/g, "%2B");
+	x[x.length] = 'subject=' + encodeURIComponent(document.forms.quickModForm['subject'].value.replace(/&#/g, "&#38;#").php_to8bit()).replace(/\+/g, "%2B");
+	x[x.length] = 'message=' + encodeURIComponent(document.forms.quickModForm['message'].value.replace(/&#/g, "&#38;#").php_to8bit()).replace(/\+/g, "%2B");
 	x[x.length] = 'topic=' + parseInt(document.forms.quickModForm.elements['topic'].value);
 	x[x.length] = 'msg=' + parseInt(document.forms.quickModForm.elements['msg'].value);
 

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -310,8 +310,8 @@ QuickModify.prototype.modifySave = function (sSessionId, sSessionVar)
 		sSessionVar = 'sesc';
 
 	var i, x = new Array();
-	x[x.length] = 'subject=' + escape(document.forms.quickModForm['subject'].value.replace(/&#/g, "&#38;#").php_to8bit()).replace(/\+/g, "%2B");
-	x[x.length] = 'message=' + escape(document.forms.quickModForm['message'].value.replace(/&#/g, "&#38;#").php_to8bit()).replace(/\+/g, "%2B");
+	x[x.length] = 'subject=' + document.forms.quickModForm['subject'].value.replace(/&#/g, "&#38;#").php_to8bit().replace(/\+/g, "%2B");
+	x[x.length] = 'message=' + document.forms.quickModForm['message'].value.replace(/&#/g, "&#38;#").php_to8bit().replace(/\+/g, "%2B");
 	x[x.length] = 'topic=' + parseInt(document.forms.quickModForm.elements['topic'].value);
 	x[x.length] = 'msg=' + parseInt(document.forms.quickModForm.elements['msg'].value);
 


### PR DESCRIPTION
SMF's JS is somehow worse than their PHP. The way strings are encoded, re-encoded and re-re-un-re-encoded is inconsistent between use cases. This commit removes two arbitrary invokations of `escape()` which appear to mangle many UTF-8 characters with no visible benefit. There are still a couple of undocumented and unexplained regex substitutions, but I chose not to touch them - trying to fix all of this is a rabbit hole I'm not prepared to delve into just yet.