### PR TITLE
Update google anal

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3438,6 +3438,16 @@ function setupThemeContext($forceload = false)
 	// ]]></script>';
 	}
 
+	// Google Analytics code snippet
+	$context['html_headers'] .= '
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-48900853-2"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag(\'js\', new Date());
+		gtag(\'config\', \'UA-48900853-2\', { \'anonymize_ip\': true });
+	</script>';
+
 	// This looks weird, but it's because BoardIndex.php references the variable.
 	$context['common_stats']['latest_member'] = array(
 		'id' => $modSettings['latestMember'],

--- a/Themes/Christmas_Season_2/index.template.php
+++ b/Themes/Christmas_Season_2/index.template.php
@@ -151,22 +151,9 @@ function template_main_above()
 	// Output any remaining HTML headers. (from mods, maybe?)
 	echo $context['html_headers'];
 
-  // Include Google Analytics stuff at the beginning of <body>
 	echo '
 </head>
-<body>
-
-<script type="text/javascript">
-  (function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
-
-  ga(\'create\', \'UA-48900853-2\', \'tfes.org\');
-  ga(\'set\', \'anonymizeIp\', true);
-  ga(\'send\', \'pageview\');
-
-</script>';
+<body>';
 /*}
 
 function template_body_above()

--- a/Themes/blanko_fes/index.template.php
+++ b/Themes/blanko_fes/index.template.php
@@ -246,21 +246,9 @@ function template_html_above()
 
 	// Output any remaining HTML headers. (from mods, maybe?)
 	echo $context['html_headers'];
-	// Include Google Analytics at the start of <body>
 	echo '
 </head>
-<body', !empty($settings['redsy_navbar']) ? ' style="padding-top: 50px;"' :  '' ,'>
-
-<script type="text/javascript">
-	(function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
-	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
-
-	ga(\'create\', \'UA-48900853-2\', \'tfes.org\');
-	ga(\'set\', \'anonymizeIp\', true);
-	ga(\'send\', \'pageview\');
-</script>';
+<body', !empty($settings['redsy_navbar']) ? ' style="padding-top: 50px;"' :  '' ,'>';
 }
 
 function template_body_above()

--- a/Themes/core/index.template.php
+++ b/Themes/core/index.template.php
@@ -176,22 +176,9 @@ function template_html_above()
 	// Output any remaining HTML headers. (from mods, maybe?)
 	echo $context['html_headers'];
 
-  // Include Google Analytics stuff at the beginning of <body>
 	echo '
 </head>
-<body>
-
-<script type="text/javascript">
-  (function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
-
-  ga(\'create\', \'UA-48900853-2\', \'tfes.org\');
-  ga(\'set\', \'anonymizeIp\', true);
-  ga(\'send\', \'pageview\');
-
-</script>';
+<body>';
 }
 
 function template_body_above()

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -169,22 +169,9 @@ function template_html_above()
 	// Output any remaining HTML headers. (from mods, maybe?)
 	echo $context['html_headers'];
 
-  // Include Google Analytics stuff at the beginning of <body>
 	echo '
 </head>
-<body>
-
-<script type="text/javascript">
-  (function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
-
-  ga(\'create\', \'UA-48900853-2\', \'tfes.org\');
-  ga(\'set\', \'anonymizeIp\', true);
-  ga(\'send\', \'pageview\');
-
-</script>';
+<body>';
 }
 
 function template_body_above()

--- a/Themes/tintagel_fes/index.template.php
+++ b/Themes/tintagel_fes/index.template.php
@@ -223,22 +223,9 @@ function template_html_above()
 	// Output any remaining HTML headers. (from mods, maybe?)
 	echo $context['html_headers'];
 
-  // Include Google Analytics stuff at the beginning of <body>
 	echo '
 </head>
-<body>
-
-<script type="text/javascript">
-  (function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
-
-  ga(\'create\', \'UA-48900853-2\', \'tfes.org\');
-  ga(\'set\', \'anonymizeIp\', true);
-  ga(\'send\', \'pageview\');
-
-</script>';
+<body>';
 }
 
 function template_body_above()


### PR DESCRIPTION
This change achieves two goals:

1. Migrate away from analytics.js in favour of gtag. This is not particularly important yet, but it prepares us for when analytics.js becomes deprecated. It also has the added benefit of being async by default, thus hypothetically improving page load times.

2. Refactor the Google Analytics snippet into Subs.php instead of maintaining individual copies of the snippet in every theme we use. I have no idea why I haven't done it like this in the first place.