### PR TITLE
Add a view_logs permission

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -384,10 +384,11 @@ function AdminMain()
 		),
 		'maintenance' => array(
 			'title' => $txt['admin_maintenance'],
-			'permission' => array('admin_forum'),
+			'permission' => array('admin_forum', 'view_logs'),
 			'areas' => array(
 				'maintain' => array(
 					'label' => $txt['maintain_title'],
+					'permission' => array('admin_forum'),
 					'file' => 'ManageMaintenance.php',
 					'icon' => 'maintain.gif',
 					'function' => 'ManageMaintenance',
@@ -400,6 +401,7 @@ function AdminMain()
 				),
 				'scheduledtasks' => array(
 					'label' => $txt['maintain_tasks'],
+					'permission' => array('admin_forum'),
 					'file' => 'ManageScheduledTasks.php',
 					'icon' => 'scheduled.gif',
 					'function' => 'ManageScheduledTasks',
@@ -410,6 +412,7 @@ function AdminMain()
 				),
 				'mailqueue' => array(
 					'label' => $txt['mailqueue_title'],
+					'permission' => array('admin_forum'),
 					'file' => 'ManageMail.php',
 					'function' => 'ManageMail',
 					'icon' => 'mail.gif',
@@ -420,6 +423,7 @@ function AdminMain()
 				),
 				'reports' => array(
 					'enabled' => in_array('rg', $context['admin_features']),
+					'permission' => array('admin_forum'),
 					'label' => $txt['generate_reports'],
 					'file' => 'Reports.php',
 					'function' => 'ReportsMain',
@@ -430,17 +434,18 @@ function AdminMain()
 					'function' => 'AdminLogs',
 					'icon' => 'logs.gif',
 					'subsections' => array(
-						'errorlog' => array($txt['errlog'], 'admin_forum', 'enabled' => !empty($modSettings['enableErrorLogging']), 'url' => $scripturl . '?action=admin;area=logs;sa=errorlog;desc'),
+						'errorlog' => array($txt['errlog'], 'view_logs', 'enabled' => !empty($modSettings['enableErrorLogging']), 'url' => $scripturl . '?action=admin;area=logs;sa=errorlog;desc'),
 						'adminlog' => array($txt['admin_log'], 'admin_forum', 'enabled' => in_array('ml', $context['admin_features'])),
-						'modlog' => array($txt['moderation_log'], 'admin_forum', 'enabled' => in_array('ml', $context['admin_features'])),
+						'modlog' => array($txt['moderation_log'], 'view_logs', 'enabled' => in_array('ml', $context['admin_features'])),
 						'banlog' => array($txt['ban_log'], 'manage_bans'),
-						'spiderlog' => array($txt['spider_logs'], 'admin_forum', 'enabled' => in_array('sp', $context['admin_features'])),
-						'tasklog' => array($txt['scheduled_log'], 'admin_forum'),
-						'pruning' => array($txt['pruning_title'], 'admin_forum'),
+						'spiderlog' => array($txt['spider_logs'], 'view_logs', 'enabled' => in_array('sp', $context['admin_features'])),
+						'tasklog' => array($txt['scheduled_log'], 'view_logs'),
+						'pruning' => array($txt['pruning_title'], 'view_logs'),
 					),
 				),
 				'repairboards' => array(
 					'label' => $txt['admin_repair'],
+					'permission' => array('admin_forum'),
 					'file' => 'RepairBoards.php',
 					'function' => 'RepairBoards',
 					'select' => 'maintain',
@@ -512,7 +517,7 @@ function AdminHome()
 	global $sourcedir, $forum_version, $txt, $scripturl, $context, $user_info, $boardurl, $modSettings, $smcFunc;
 
 	// You have to be able to do at least one of the below to see this page.
-	isAllowedTo(array('admin_forum', 'manage_permissions', 'moderate_forum', 'manage_membergroups', 'manage_bans', 'send_mail', 'edit_news', 'manage_boards', 'manage_smileys', 'manage_attachments'));
+	isAllowedTo(array('admin_forum', 'manage_permissions', 'moderate_forum', 'manage_membergroups', 'manage_bans', 'send_mail', 'edit_news', 'view_logs', 'manage_boards', 'manage_smileys', 'manage_attachments'));
 
 	// Find all of this forum's administrators...
 	require_once($sourcedir . '/Subs-Membergroups.php');

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -49,7 +49,7 @@ function ViewErrorLog()
 		return ViewFile();
 
 	// Check for the administrative permission to do this.
-	isAllowedTo('admin_forum');
+	isAllowedTo('view_logs');
 
 	// Templates, etc...
 	loadLanguage('ManageMaintenance');

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1477,6 +1477,7 @@ function loadAllPermissions($loadType = 'classic')
 			'manage_attachments' => array(false, 'maintenance', 'administrate'),
 			'manage_smileys' => array(false, 'maintenance', 'administrate'),
 			'edit_news' => array(false, 'maintenance', 'administrate'),
+			'view_logs' => array(false, 'maintenance', 'administrate'),
 			'access_mod_center' => array(false, 'maintenance', 'moderate_general'),
 			'moderate_forum' => array(false, 'member_admin', 'moderate_general'),
 			'manage_membergroups' => array(false, 'member_admin', 'administrate'),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4052,7 +4052,7 @@ function setupMenuContext()
 					'errorlog' => array(
 						'title' => $txt['errlog'],
 						'href' => $scripturl . '?action=admin;area=logs;sa=errorlog;desc',
-						'show' => allowedTo('admin_forum') && !empty($modSettings['enableErrorLogging']),
+						'show' => allowedTo('view_logs') && !empty($modSettings['enableErrorLogging']),
 					),
 					'permissions' => array(
 						'title' => $txt['edit_permissions'],

--- a/Themes/blanko_fes/css/index.css
+++ b/Themes/blanko_fes/css/index.css
@@ -5918,19 +5918,6 @@ a.link-to-home
     }
 }
 
-@media (max-width: 991px)
-{
-    #admin_content .table > thead > tr > th:nth-child(2), #admin_content .table > tbody > tr > td:nth-child(2),
-    #admin_content .table > thead > tr > th:nth-child(4), #admin_content .table > tbody > tr > td:nth-child(4),
-    #admin_content .table > thead > tr > th:nth-child(5), #admin_content .table > tbody > tr > td:nth-child(5) {
-        display: none;
-    }
-    #admin_content .table > thead > tr > th:last-child, #admin_content .table > tbody > tr > td:last-child {
-        display: table-cell !important;
-        text-align: right !important;
-    }
-}
-
 #IC .nav
 {
     margin: 0;

--- a/Themes/default/languages/ManagePermissions.english.php
+++ b/Themes/default/languages/ManagePermissions.english.php
@@ -114,6 +114,8 @@ $txt['permissionname_manage_smileys'] = 'Manage smileys and message icons';
 $txt['permissionhelp_manage_smileys'] = 'This allows access to the smiley center. In the smiley center you can add, edit and remove smileys and smiley sets. If you\'ve enabled customized message icons you are also able to add and edit message icons with this permission.';
 $txt['permissionname_edit_news'] = 'Edit news';
 $txt['permissionhelp_edit_news'] = 'The news function allows a random news line to appear on each screen. In order to use the news function, enabled it in the forum settings.';
+$txt['permissionname_view_logs'] = 'View logs';
+$txt['permissionhelp_view_logs'] = 'Read various forum logs, which may include sensitive user and/or database information.';
 $txt['permissionname_access_mod_center'] = 'Access the moderation center';
 $txt['permissionhelp_access_mod_center'] = 'With this permission any members of this group can access the moderation center from where they will have access to functionality to ease moderation. Note that this does not in itself grant any moderation privileges.';
 


### PR DESCRIPTION
This lets us allow specific membergroups to read the forum logs without needing to be admins. It also removes some CSS that has been there since the blanko_fes theme was added but seems to do nothing other than break the log view for non-admins.