### PR TITLE
Stop unitialised sub vars in CN 

### DIFF
--- a/Themes/Christmas_Season_2/Display.template.php
+++ b/Themes/Christmas_Season_2/Display.template.php
@@ -221,9 +221,9 @@ function template_main()
 		$buttonArray[] = '<a href="' . $scripturl . '?action=post;topic=' . $context['current_topic'] . '.' . $context['start'] . ';num_replies=' . $context['num_replies'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/reply.gif" alt="' . $txt['reply'] . '" border="0" />' : $txt['reply']) . '</a>';
 
 	CheckUnsubscribe();
-	if ($context['is_subscribed'])
+	if (!empty($context['is_subscribed']) and $context['is_subscribed'])
 		$buttonArray[] = '<a href="' . $scripturl . '?action=unsubscribe;unsubscribe=1;topic=' . $context['current_topic'] . ';return=' . $context['start'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/topic_unsubscribe.gif" alt="' . $txt['unsubscribe'] . '" border="0" />' : $txt['unsubscribe']) . '</a>';
-	if ($context['is_unsubscribed'])
+	if (!empty($context['is_unsubscribed']) and $context['is_unsubscribed'])
 		$buttonArray[] = '<a href="' . $scripturl . '?action=unsubscribe;unsubscribe=0;topic=' . $context['current_topic'] . ';return=' . $context['start'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/topic_subscribe.gif" alt="' . $txt['subscribe'] . '" border="0" />' : $txt['subscribe']) . '</a>';
 
 	if ($context['can_add_poll'])
@@ -644,29 +644,6 @@ function template_main()
 						<a id="bot"></a><strong>', $txt['pages'], ':</strong> ', $context['page_index'], (!empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '<a href="#top">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/go_up.gif" alt="' . $txt['go_up'] . '" border="0" align="top" />' : $txt['go_up']) . '</a>' : ''), '
 					</td>
 					<td align="', !$context['right_to_left'] ? 'right' : 'left', '" style="font-size: smaller;">';
-
-	CheckUnsubscribe();
-	$buttonArray = array();
-	if ($context['can_reply'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=post;topic=' . $context['current_topic'] . '.' . $context['start'] . ';num_replies=' . $context['num_replies'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/reply.gif" alt="' . $txt['reply'] . '" border="0" />' : $txt['reply']) . '</a>';
-
-	if ($context['is_subscribed'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=unsubscribe;unsubscribe=1;topic=' . $context['current_topic'] . ';return=' . $context['start'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/topic_unsubscribe.gif" alt="' . $txt['unsubscribe'] . '" border="0" />' : $txt['unsubscribe']) . '</a>';
-	if ($context['is_unsubscribed'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=unsubscribe;unsubscribe=0;topic=' . $context['current_topic'] . ';return=' . $context['start'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/topic_subscribe.gif" alt="' . $txt['subscribe'] . '" border="0" />' : $txt['subscribe']) . '</a>';
-
-	if ($context['can_add_poll'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=editpoll;add;topic=' . $context['current_topic'] . '.' . $context['start'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/addpoll.gif" alt="' . $txt['add_poll'] . '" border="0" />' : $txt['add_poll']) . '</a>';
-
-	if ($context['can_mark_notify'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=notify;sa=' . ($context['is_marked_notify'] ? 'off' : 'on') . ';topic=' . $context['current_topic'] . '.' . $context['start'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" onclick="return confirm(\'' . ($context['is_marked_notify'] ? $txt['notification_disable_topic'] : $txt['notification_enable_topic']) . '\');">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/' . ($context['is_marked_notify'] ? 'un' : '') . 'notify.gif" alt="' . $txt[$context['is_marked_notify'] ? 'unnotify' : 'notify'] . '" border="0" />' : $txt[$context['is_marked_notify'] ? 'unnotify' : 'notify']) . '</a>';
-
-	if ($context['user']['is_logged'] && $settings['show_mark_read'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=markasread;sa=topic;t=' . $context['mark_unread_time'] . ';topic=' . $context['current_topic'] . '.' . $context['start'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/markunread.gif" alt="' . $txt['mark_unread'] . '" border="0" />' : $txt['mark_unread']) . '</a>';
-
-	if ($context['can_send_topic'])
-		$buttonArray[] = '<a href="' . $scripturl . '?action=emailuser;sa=sendtopic;topic=' . $context['current_topic'] . '.0">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/sendtopic.gif" alt="' . $txt['send_topic'] . '" border="0" />' : $txt['send_topic']) . '</a>';
-	$buttonArray[] = '<a href="' . $scripturl . '?action=printpage;topic=' . $context['current_topic'] . '.0" target="_blank" class="new_win">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/print.gif" alt="' . $txt['print'] . '" border="0" />' : $txt['print']) . '</a>';
 
 	echo implode($context['menu_separator'], $buttonArray);
 

--- a/Themes/Christmas_Season_2/Display.template.php
+++ b/Themes/Christmas_Season_2/Display.template.php
@@ -645,6 +645,7 @@ function template_main()
 					</td>
 					<td align="', !$context['right_to_left'] ? 'right' : 'left', '" style="font-size: smaller;">';
 
+	CheckUnsubscribe();
 	$buttonArray = array();
 	if ($context['can_reply'])
 		$buttonArray[] = '<a href="' . $scripturl . '?action=post;topic=' . $context['current_topic'] . '.' . $context['start'] . ';num_replies=' . $context['num_replies'] . '">' . ($settings['use_image_buttons'] ? '<img src="' . $settings['lang_images_url'] . '/reply.gif" alt="' . $txt['reply'] . '" border="0" />' : $txt['reply']) . '</a>';


### PR DESCRIPTION
This commit suppresses needless uninitialised variable errors from $context['is subscribed'] and $context['is_unsubscribed'] in CN. It also removes some code duplication - the menu buttons were generated separately for the top and bottom menu despite being identical.