### PR TITLE
Don't generate next/prev links when impossible

### DIFF
--- a/Themes/Christmas_Season_2/index.template.php
+++ b/Themes/Christmas_Season_2/index.template.php
@@ -107,7 +107,7 @@ function template_main_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']))
+	if (!empty($context['current_topic']) && !empty($context["page_index"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/Christmas_Season_2/index.template.php
+++ b/Themes/Christmas_Season_2/index.template.php
@@ -107,7 +107,7 @@ function template_main_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && !empty($context["page_index"]))
+	if (!empty($context['current_topic']) && !empty($context["start"]) && !empty($context["messages_per_page"]) && !empty($context["total_visible_posts"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/blanko_fes/index.template.php
+++ b/Themes/blanko_fes/index.template.php
@@ -633,17 +633,17 @@ function pages_titlesdesc()
 {
 	global $txt, $context, $scripturl, $settings, $modSettings, $options, $sourcedir, $topic, $topicinfo, $board_info, $board, $category;
 
-	if(!empty($topic))
+	if(!empty($topic) && !empty($context['subject']))
 	{
 		echo '
 		<h2>', $context['subject'], '</h2>';
 	}
-	elseif(!empty($board))
+	elseif(!empty($board) && !empty($board_info['name']))
 	{
 		echo '
 		<h2>',$board_info['name'],'</h2>';
 	}
-	else
+	elseif(!empty($context['page_title']))
 	{
 		echo '
 		<h2>',$context['page_title'],'</h2>';

--- a/Themes/blanko_fes/index.template.php
+++ b/Themes/blanko_fes/index.template.php
@@ -227,7 +227,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && empty($context['current_action']))
+	if (!empty($context['current_topic']) && empty($context['current_action']) && !empty($context["page_index"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/blanko_fes/index.template.php
+++ b/Themes/blanko_fes/index.template.php
@@ -227,7 +227,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && empty($context['current_action']) && !empty($context["page_index"]))
+	if (!empty($context['current_topic']) && empty($context['current_action']) && !empty($context["start"]) && !empty($context["messages_per_page"]) && !empty($context["total_visible_posts"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/core/index.template.php
+++ b/Themes/core/index.template.php
@@ -149,7 +149,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']))
+	if (!empty($context['current_topic']) && !empty($context["page_index"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/core/index.template.php
+++ b/Themes/core/index.template.php
@@ -149,7 +149,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && !empty($context["page_index"]))
+	if (!empty($context['current_topic']) && !empty($context["start"]) && !empty($context["messages_per_page"]) && !empty($context["total_visible_posts"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -149,7 +149,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']))
+	if (!empty($context['current_topic']) && !empty($context["page_index"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -149,7 +149,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && !empty($context["page_index"]))
+	if (!empty($context['current_topic']) && !empty($context["start"]) && !empty($context["messages_per_page"]) && !empty($context["total_visible_posts"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/tintagel_fes/index.template.php
+++ b/Themes/tintagel_fes/index.template.php
@@ -197,7 +197,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && empty($context['current_action']))
+	if (!empty($context['current_topic']) && empty($context['current_action']) && !empty($context["page_index"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];

--- a/Themes/tintagel_fes/index.template.php
+++ b/Themes/tintagel_fes/index.template.php
@@ -197,7 +197,7 @@ function template_html_above()
 	// If we're viewing a topic, these should be the previous and next pages of the same topic, respectively.
 	// For some reason SMF developers thought that the best thing to put down as the "next page" is the next thread.
 	// That's retarded, and thus now fixed.
-	if (!empty($context['current_topic']) && empty($context['current_action']) && !empty($context["page_index"]))
+	if (!empty($context['current_topic']) && empty($context['current_action']) && !empty($context["start"]) && !empty($context["messages_per_page"]) && !empty($context["total_visible_posts"]))
 	{
 		$next_page = $context['start'] + $context['messages_per_page'];
 		$prev_page = $context['start'] - $context['messages_per_page'];


### PR DESCRIPTION
If a user tries to look at a thread, but is unable to (e.g. due to lacking privileges), the forum still attempts to generate a set of rel next/prev links. This can't work, because we have no access to any details of the thread involved. Shockingly, this results in error log spam.

Unfortunately, SMF offers no variable for "a thread has been selected and is also actually being viewed", so fixing this is a bit hacky. I opted to assume that any thread with pages that can be viewed will have a page index. This may or may not be a bit brave, since we're working with SMF.

These next/prev links are bordering on deprecated, so risk of regression is minimal. We *could* consider simply removing them altogether, but technically they carry some semantic value, and for all we know there might be one piece of software somewhere that actually uses them.

EDIT:  The same error messages would try to generate `<h2>`s based on information they don't have access to. Since this is the same class of error, I've included it within the same PR.