### PR TITLE
No post approval in recent topics

### DIFF
--- a/Themes/blanko_fes/Recent.template.php
+++ b/Themes/blanko_fes/Recent.template.php
@@ -148,9 +148,6 @@ function template_unread()
 
 		foreach ($context['topics'] as $topic)
 		{
-			// Is this topic pending approval, or does it have any posts pending approval?
-			if ($context['can_approve_posts'] && $topic['unapproved_posts'])
-				$color_class = !$topic['approved'] ? 'approvetbg' : 'approvebg';
 			// We start with locked and sticky topics.
 			elseif ($topic['is_sticky'] && $topic['is_locked'])
 				$color_class = 'stickybg locked_sticky';
@@ -361,7 +358,7 @@ function template_replies()
 		foreach ($context['topics'] as $topic)
 		{
 			// Is this topic pending approval, or does it have any posts pending approval?
-			if ($context['can_approve_posts'] && $topic['unapproved_posts'])
+			if (!empty($context['can_approve_posts']) && $context['can_approve_posts'] && $topic['unapproved_posts'])
 				$color_class = !$topic['approved'] ? 'approvetbg' : 'approvebg';
 			// We start with locked and sticky topics.
 			elseif ($topic['is_sticky'] && $topic['is_locked'])

--- a/Themes/blanko_fes/Recent.template.php
+++ b/Themes/blanko_fes/Recent.template.php
@@ -149,7 +149,7 @@ function template_unread()
 		foreach ($context['topics'] as $topic)
 		{
 			// We start with locked and sticky topics.
-			elseif ($topic['is_sticky'] && $topic['is_locked'])
+			if ($topic['is_sticky'] && $topic['is_locked'])
 				$color_class = 'stickybg locked_sticky';
 			// Sticky topics should get a different color, too.
 			elseif ($topic['is_sticky'])
@@ -357,11 +357,8 @@ function template_replies()
 
 		foreach ($context['topics'] as $topic)
 		{
-			// Is this topic pending approval, or does it have any posts pending approval?
-			if (!empty($context['can_approve_posts']) && $context['can_approve_posts'] && $topic['unapproved_posts'])
-				$color_class = !$topic['approved'] ? 'approvetbg' : 'approvebg';
 			// We start with locked and sticky topics.
-			elseif ($topic['is_sticky'] && $topic['is_locked'])
+			if ($topic['is_sticky'] && $topic['is_locked'])
 				$color_class = 'stickybg locked_sticky';
 			// Sticky topics should get a different color, too.
 			elseif ($topic['is_sticky'])


### PR DESCRIPTION
blanko_fes tries to highlight unapproved posts in the recent topics view. We don't use topic approval, and SMF does not set the necessary variables for this to ever work in this view. This functionality could never have worked, so it might as well stop generating errors.