### PR TITLE
No lurk ratio for users with 0 posts/0 time logged in

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -684,12 +684,23 @@ function statPanel($memID)
 	$context['num_posts'] = comma_format($user_profile[$memID]['posts']);
 
 	//Personal lurk ratio.
-	$lurkRatio = $user_profile[$memID]['total_time_logged_in']/$user_profile[$memID]['posts'];
-	$lurkDays = floor($lurkRatio / 86400);
-	$lurkHours = floor(($lurkRatio % 86400) / 3600);
-	$lurkMinutes = floor(($lurkRatio % 3600) / 60);
-	$lurkSeconds = $lurkRatio % 60;
-	$context['lurk_ratio'] = ($lurkDays > 0 ? $lurkDays . " days, " : '') . ($lurkHours > 0 ? $lurkHours . " hours, " : '') . ($lurkMinutes > 0 ? $lurkMinutes . " minutes and " : '') . $lurkSeconds . " seconds per post.";
+	if($user_profile[$memID]['total_time_logged_in'] > 0 && $user_profile[$memID]['posts'] > 0)
+	{
+		$lurkRatio = $user_profile[$memID]['total_time_logged_in']/$user_profile[$memID]['posts'];
+		$lurkDays = floor($lurkRatio / 86400);
+		$lurkHours = floor(($lurkRatio % 86400) / 3600);
+		$lurkMinutes = floor(($lurkRatio % 3600) / 60);
+		$lurkSeconds = $lurkRatio % 60;
+		$context['lurk_ratio'] = ($lurkDays > 0 ? $lurkDays . " days, " : '') .
+					($lurkHours > 0 ? $lurkHours . " hours, " : '') .
+					($lurkMinutes > 0 ? $lurkMinutes . " minutes, " : '') .
+					($lurkSeconds > 0 ? $lurkSeconds . " seconds " : '') .
+					"per post.";
+	}
+	else
+	{
+		$context['lurk_ratio'] = "N/A";
+	}
 	
 	// Number of topics started.
 	$result = $smcFunc['db_query']('', '

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -546,12 +546,13 @@ function DisplayStats()
 	$members_result = $smcFunc['db_query']('', '
 		SELECT id_member, real_name, posts, total_time_logged_in
 		FROM {db_prefix}members ' . (!empty($temp_lurk) ? '
-		WHERE id_member IN ({array_int:member_list_cached})' : 'WHERE posts > {int:no_posts}') . '
+		WHERE id_member IN ({array_int:member_list_cached})' : 'WHERE posts > {int:no_posts} AND total_time_logged_in > {int:time_logged_in}') . '
 		ORDER BY total_time_logged_in/posts DESC
 		LIMIT 10',
 		array(
 			'member_list_cached' => $temp_lurk,
 			'no_posts' => 0,
+			'time_logged_in' => 0,
 		)
 	);
 	$context['top_lurk'] = array();
@@ -606,12 +607,13 @@ function DisplayStats()
 	$members_result = $smcFunc['db_query']('', '
 		SELECT id_member, real_name, posts, total_time_logged_in
 		FROM {db_prefix}members ' . (!empty($temp_lurk) ? '
-		WHERE id_member IN ({array_int:member_list_cached})' : 'WHERE posts > {int:no_posts}') . '
+		WHERE id_member IN ({array_int:member_list_cached})' : 'WHERE posts > {int:no_posts} AND total_time_logged_in > {int:time_logged_in}') . '
 		ORDER BY total_time_logged_in/posts ASC
 		LIMIT 10',
 		array(
 			'member_list_cached' => $temp_lurk,
 			'no_posts' => 0,
+			'time_logged_in' => 0
 		)
 	);
 	$context['worst_lurk'] = array();


### PR DESCRIPTION
Users who have not created any posts or for whom SMF has not measured any time online cannot be given a meaningful lurk ratio stat. These have now been constrained away both in forum stats and profile stats.

This commit also slightly refactors the format of the lurk ratio string in per-profile stats to prevent awkward outputs like "69 days and 0 seconds per post". Seconds were previously displayed unconditionally (I don't know why I did it that way), and now they're not.