### PR TITLE
Don't generate a mark read button in recent posts

### DIFF
--- a/Themes/blanko_fes/Recent.template.php
+++ b/Themes/blanko_fes/Recent.template.php
@@ -23,7 +23,6 @@ function template_main()
 		</div>
 	<div class="pagesection">
 		<div class="pagelinks floatleft">', $txt['pages'], ': ', $context['page_index'], !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '&nbsp;&nbsp;<a href="#bot"><strong>' . $txt['go_down'] . '</strong></a>' : '', '</div>
-		', template_button_strip($mark_read, 'right'), '
 	</div>';
 
 	foreach ($context['posts'] as $post)
@@ -79,7 +78,6 @@ function template_main()
 	echo '
 	<div class="pagesection">
 		<div class="pagelinks floatleft">', $txt['pages'], ': ', $context['page_index'], !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '&nbsp;&nbsp;<a href="#bot"><strong>' . $txt['go_down'] . '</strong></a>' : '', '</div>
-		', template_button_strip($mark_read, 'right'), '
 	</div>
 	</div>';
 }


### PR DESCRIPTION
The ["Recent Posts" view](https://forum.tfes.org/index.php?action=recent) of blanko_fes currently attempts to generate a "mark all posts as read" button by invoking an unitialised variable. This obviously fails, producing no output to users other than logging a few errors in our precious log.

I can think of two approaches of fixing this: either actually define the button, or stop trying to generate it. My logic is that since the button was never there for users, there is no need to add it now. On top of that, a button to mark all posts as read could be detrimental in a context which does not clearly illustrate which posts would and wouldn't be affected.