### PR TITLE
Fix hostname bans

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -451,7 +451,7 @@ function BanEdit()
 		}
 		elseif ($_POST['bantype'] == 'hostname_ban')
 		{
-			if (preg_match('/[^\w.\-*]/', $_POST['hostname']) == 1)
+			if (preg_match('/[^\w.\-:*]/', $_POST['hostname']) == 1)
 				fatal_lang_error('invalid_hostname', false);
 
 			// Replace the * wildcard by a MySQL compatible wildcard %.
@@ -642,7 +642,7 @@ function BanEdit()
 				}
 				if (in_array('hostname', $_POST['ban_suggestion']) && !empty($_POST['hostname']))
 				{
-					if (preg_match('/[^\w.\-*]/', $_POST['hostname']) == 1)
+					if (preg_match('/[^\w.\-:*]/', $_POST['hostname']) == 1)
 						fatal_lang_error('invalid_hostname', false);
 
 					// Replace the * wildcard by a MySQL wildcard %.

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -247,17 +247,6 @@ function is_not_banned($forceCheck = false)
 							AND (' . $ip_parts[2] . ' BETWEEN bi.ip_low2 AND bi.ip_high2)
 							AND (' . $ip_parts[3] . ' BETWEEN bi.ip_low3 AND bi.ip_high3)
 							AND (' . $ip_parts[4] . ' BETWEEN bi.ip_low4 AND bi.ip_high4))';
-
-				// IP was valid, maybe there's also a hostname...
-				if (empty($modSettings['disableHostnameLookup']))
-				{
-					$hostname = host_from_ip($user_info[$ip_number]);
-					if (strlen($hostname) > 0)
-					{
-						$ban_query[] = '({string:hostname} LIKE bi.hostname)';
-						$ban_query_vars['hostname'] = $hostname;
-					}
-				}
 			}
 			// We use '255.255.255.255' for 'unknown' since it's not valid anyway.
 			elseif ($user_info['ip'] == 'unknown')
@@ -265,6 +254,20 @@ function is_not_banned($forceCheck = false)
 							AND bi.ip_low2 = 255 AND bi.ip_high2 = 255
 							AND bi.ip_low3 = 255 AND bi.ip_high3 = 255
 							AND bi.ip_low4 = 255 AND bi.ip_high4 = 255)';
+		}
+
+		
+		if (empty($modSettings['disableHostnameLookup']))
+		{
+			foreach (array('ip', 'ip2') as $ip_number)
+			{
+				$hostname = host_from_ip($user_info[$ip_number]);
+				if (strlen($hostname) > 0)
+				{
+					$ban_query[] = '({string:hostname} LIKE bi.hostname)';
+					$ban_query_vars['hostname'] = $hostname;
+				}
+			}
 		}
 
 		// Is their email address banned?


### PR DESCRIPTION
Originally, SMF would only check for hostname bans if the user's IP address passed the gauntlet of insanity (lots of convoluted code that largely attempts to check if it's a valid IPv4 address).

This check appears to be unnecessary - if for whatever reason the IP address is malformed, `host_from_ip()` will simply return `false`, and the rest of the hostname ban check will be skipped. In addition, original behaviour prevented hostname checks to ever happen if the user's IP is IPv6.

Also, since we currently don't have a functioning IPv6 ban, we should allow for colons in hostname bans as a workaround.