### PR TITLE
Fix memberlist sorting by online status

### DIFF
--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -290,8 +290,8 @@ function MLAll()
 	// List out the different sorting methods...
 	$sort_methods = array(
 		'is_online' => array(
-			'down' => allowedTo('moderate_forum') ? 'IFNULL(lo.log_time, 1) ASC, real_name ASC' : 'CASE WHEN mem.show_online THEN IFNULL(lo.log_time, 1) ELSE 1 END ASC, real_name ASC',
-			'up' => allowedTo('moderate_forum') ? 'IFNULL(lo.log_time, 1) DESC, real_name DESC' : 'CASE WHEN mem.show_online THEN IFNULL(lo.log_time, 1) ELSE 1 END DESC, real_name DESC'
+			'down' => allowedTo('moderate_forum') ? 'IFNULL(lo.log_time, 1) ASC, real_name ASC' : 'CASE WHEN mem.show_online = 1 THEN IFNULL(lo.log_time, 1) ELSE 1 END ASC, real_name ASC',
+			'up' => allowedTo('moderate_forum') ? 'IFNULL(lo.log_time, 1) DESC, real_name DESC' : 'CASE WHEN mem.show_online = 1 THEN IFNULL(lo.log_time, 1) ELSE 1 END DESC, real_name DESC'
 		),
 		'real_name' => array(
 			'down' => 'mem.real_name DESC',


### PR DESCRIPTION
SMF's current implementation of sorting members by their online status relies on incorrectly checking whether `mem.show_online` is true (for non-moderators, so they can't see users who asked to hide their online status).

`mem.show_online` is a smallint, not a boolean. It could (should?) probably become a boolean, but I imagine this would wreak havoc somewhere else. Instead, let's just compare this number to 1 to get a boolean out.