### PR TITLE
Remove invisible form fields from the registration form

### DIFF
--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -150,12 +150,6 @@ function template_registration_form()
 				<span class="topslice"><span></span></span>
 				<fieldset class="content">
 					<dl class="register_form">
-						<div style="display: none">
-							<input type="text" name="user" />
-							<input type="text" name="email" />
-							<input type="password" name="passwrd1" />
-							<input type="password" name="passwrd2" />
-						</div>
 						<dt><strong><label for="smf_autov_username">', $txt['username'], ':</label></strong></dt>
 						<dd>
 							<input type="text" name="', $_SESSION['antibotuf']['user'] ,'" id="smf_autov_username" size="30" tabindex="', $context['tabindex']++, '" maxlength="25" value="', isset($context['username']) ? $context['username'] : '', '" class="input_text" />


### PR DESCRIPTION
Originally, when we rolled out our antispam measures, these fields were left in place to hopefully trip up some bot registrations. However, their presence appears to interfere with some password managers, who choose to fill these boxes, thus leading to unsuccessful legitimate registrations.

There is no evidence that having these fields in the form provides any benefit, so let's get rid of them.