### PR TITLE
Revert registration form back to its glory days

### DIFF
--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -150,6 +150,12 @@ function template_registration_form()
 				<span class="topslice"><span></span></span>
 				<fieldset class="content">
 					<dl class="register_form">
+						<div style="display: none">
+							<input type="text" name="user" />
+							<input type="text" name="email" />
+							<input type="password" name="passwrd1" />
+							<input type="password" name="passwrd2" />
+						</div>
 						<dt><strong><label for="smf_autov_username">', $txt['username'], ':</label></strong></dt>
 						<dd>
 							<input type="text" name="', $_SESSION['antibotuf']['user'] ,'" id="smf_autov_username" size="30" tabindex="', $context['tabindex']++, '" maxlength="25" value="', isset($context['username']) ? $context['username'] : '', '" class="input_text" />

--- a/Themes/default/languages/Errors.english-utf8.php
+++ b/Themes/default/languages/Errors.english-utf8.php
@@ -3,7 +3,7 @@
 
 global $scripturl, $modSettings;
 
-$txt['fake_form_filled'] = 'Your registration cannot be completed at this time. If this problem persists, please contact us at admin@tfes.org';
+$txt['fake_form_filled'] = 'Your registration cannot be completed at this time. If this problem persists, please contact us at contact@tfes.org';
 
 $txt['no_access'] = 'You are not allowed to access this section';
 $txt['wireless_error_notyet'] = 'Sorry, this section isn\'t available for wireless users at this time.';

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -3,7 +3,7 @@
 
 global $scripturl, $modSettings;
 
-$txt['fake_form_filled'] = 'Your registration cannot be completed at this time. If this problem persists, please contact us at admin@tfes.org';
+$txt['fake_form_filled'] = 'Your registration cannot be completed at this time. If this problem persists, please contact us at contact@tfes.org';
 
 $txt['no_access'] = 'You are not allowed to access this section';
 $txt['wireless_error_notyet'] = 'Sorry, this section isn\'t available for wireless users at this time.';


### PR DESCRIPTION
Recent attempts at improving the registration form led to a hundred-fold increase in successful spammer registrations.

Let's not do that. Also, let's make sure that the unsuccessful registration message directs people to an inbox that's actually read.